### PR TITLE
Card group component

### DIFF
--- a/src/app/(components)/card-group/page.tsx
+++ b/src/app/(components)/card-group/page.tsx
@@ -3,7 +3,13 @@ import { CardGroup } from "@/modules/core/components"
 export default function Page() {
     return (
         <div>
-            <CardGroup/>
+            <CardGroup
+                title="Proyecto X"
+                description="Descripción del proyecto X"
+                labelRef="Ver detalles"
+                progress={75}
+                states={true}
+            />
         </div>
     )
 }

--- a/src/app/(components)/card-group/page.tsx
+++ b/src/app/(components)/card-group/page.tsx
@@ -1,0 +1,9 @@
+import { CardGroup } from "@/modules/core/components"
+
+export default function Page() {
+    return (
+        <div>
+            <CardGroup/>
+        </div>
+    )
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-xl border bg-card text-card-foreground shadow",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/src/modules/core/components/CardGroup/CardGroup.tsx
+++ b/src/modules/core/components/CardGroup/CardGroup.tsx
@@ -1,0 +1,43 @@
+import * as React from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardFooter,
+    CardHeader,
+    CardTitle,
+} from "@/components/ui/card"
+import { Users } from "lucide-react"
+
+
+export function CardGroup() {
+    return (
+        <Card className="max-w-[350px]">
+            <CardHeader>
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-4">
+                        <div className="border-2 rounded-md p-3 shadow-lg">
+                            <Users />
+                        </div>
+                        <div className="flex items-center justify-center border-2 rounded-md px-2 py-1 ">
+                            <h1 className="text-sm">Estado</h1>
+                        </div>
+                    </div>
+                    <div className="flex">
+                        <h1>10%</h1>
+                        <div className="rounded-full bg-green-500 h-2 w-full">g</div>
+                    </div>
+                </div>
+            </CardHeader>
+            <CardContent>
+                <CardTitle><p className="line-clamp-1">Matematica - 5to A </p></CardTitle>
+                <CardDescription>Turno: Mañana</CardDescription>
+            </CardContent>
+            <CardFooter className="flex justify-between">
+                <Button>Deploy</Button>
+            </CardFooter>
+        </Card>
+    )
+}

--- a/src/modules/core/components/CardGroup/CardGroup.tsx
+++ b/src/modules/core/components/CardGroup/CardGroup.tsx
@@ -1,6 +1,4 @@
 import * as React from "react"
-
-import { Button } from "@/components/ui/button"
 import {
     Card,
     CardContent,
@@ -10,9 +8,20 @@ import {
     CardTitle,
 } from "@/components/ui/card"
 import { Users } from "lucide-react"
+import Circleprogress from "./component/circleprogress"
+import Link from "next/dist/client/link"
+import { Button } from "@/components/ui/button"
+
+interface ICardGroupProps {
+    title: string,
+    description: string,
+    labelRef: string,
+    progress: number,
+    states: boolean,
+}
 
 
-export function CardGroup() {
+export function CardGroup({title = 'Title', description = 'Description', labelRef='Default', progress = 0, states=true} : ICardGroupProps) {
     return (
         <Card className="max-w-[350px]">
             <CardHeader>
@@ -22,21 +31,27 @@ export function CardGroup() {
                             <Users />
                         </div>
                         <div className="flex items-center justify-center border-2 rounded-md px-2 py-1 ">
-                            <h1 className="text-sm">Estado</h1>
+                            <h1 className="text-sm">{states ? 'En curso' : 'Terminado'}</h1>
                         </div>
                     </div>
                     <div className="flex">
-                        <h1>10%</h1>
-                        <div className="rounded-full bg-green-500 h-2 w-full">g</div>
+                        <Circleprogress value={progress} />
                     </div>
                 </div>
             </CardHeader>
             <CardContent>
-                <CardTitle><p className="line-clamp-1">Matematica - 5to A </p></CardTitle>
-                <CardDescription>Turno: Mañana</CardDescription>
+                <CardTitle><p className="line-clamp-1 mb-2">{title}</p></CardTitle>
+                <CardDescription>{description}</CardDescription>
             </CardContent>
             <CardFooter className="flex justify-between">
-                <Button>Deploy</Button>
+                <Button asChild>
+                    <Link
+                        href="/"
+                        className="bg-"
+                    >
+                        {labelRef}
+                    </Link>
+                </Button>
             </CardFooter>
         </Card>
     )

--- a/src/modules/core/components/CardGroup/component/circleprogress.tsx
+++ b/src/modules/core/components/CardGroup/component/circleprogress.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import React from "react";
+
+interface CircleProgressProps {
+    value: number; // Valor a mostrar en el círculo
+    size?: number; // Tamaño del SVG (opcional)
+    radius?: number; // Radio del círculo (opcional)
+}
+
+export default function Circleprogress({ value, size = 50, radius = 10 }: CircleProgressProps) {
+    const circumference = 2 * Math.PI * radius;
+
+    return (
+        <div className="flex items-center justify-center">
+            <div className="font-semibold text-black ">
+                {value}%
+            </div>
+            <svg
+                className="rotate-[-90deg]"
+                width={size}
+                height={size}
+            >
+                <circle
+                    className="text-gray-200"
+                    strokeWidth="3"
+                    stroke="currentColor"
+                    fill="transparent"
+                    r={radius}
+                    cx={size / 2}
+                    cy={size / 2}
+                />
+                <circle
+                    className="text-black-200"
+                    strokeWidth="3"
+                    strokeDasharray={circumference}
+                    strokeDashoffset={circumference - (value / 100) * circumference}
+                    strokeLinecap="round"
+                    stroke="currentColor"
+                    fill="transparent"
+                    r={radius}
+                    cx={size / 2}
+                    cy={size / 2}
+                />
+            </svg>
+        </div>
+    );
+}

--- a/src/modules/core/components/index.ts
+++ b/src/modules/core/components/index.ts
@@ -2,5 +2,6 @@ import { NavBarCustom } from './NavBarCustom/NavBarCustom'
 import { LoginComponent } from './Login/LoginComponent'
 import { UserDropdown } from './UserDropdown/UserDropdown'
 import { HeaderSection } from './HeaderSection/HeaderSection'
+import { CardGroup } from './CardGroup/CardGroup'
 
-export { NavBarCustom, UserDropdown, HeaderSection, LoginComponent }
+export { NavBarCustom, UserDropdown, HeaderSection, LoginComponent, CardGroup }


### PR DESCRIPTION
### Documentación de los Componentes CardGroup y Circleprogress
**CardGroup**
El componente CardGroup es una tarjeta diseñada para presentar información relevante sobre un grupo, proyecto, o entidad específica. Incluye un indicador de progreso circular, un estado visual de la actividad, y un enlace de acción que redirige a una página específica.

**Props:**

- title (string): El título que se mostrará en el contenido de la tarjeta.
- description (string): La descripción que se mostrará en el contenido de la tarjeta.
- labelRef (string): El texto del botón en el pie de página que sirve como etiqueta y enlace.
- progress (number): El valor de progreso a mostrar en el componente Circleprogress.
- states (boolean): Determina el estado actual del elemento; muestra "En curso" si es true y "Terminado" si es false.

**Estructura:**

- CardHeader: Contiene un ícono (Users de lucide-react) y un indicador de estado que muestra si está "En curso" o "Terminado". También incluye el componente Circleprogress para visualizar el progreso.
- CardContent: Muestra el título (title) y la descripción (description) del contenido de la tarjeta.
- CardFooter: Contiene un botón que enlaza a la ruta especificada por labelRef.

Ejemplo de uso:
```
<CardGroup 
    title="Proyecto X"
    description="Descripción del proyecto X"
    labelRef="Ver detalles"
    progress={75}
    states={true}
/>
```
**Circleprogress**
El componente Circleprogress se utiliza dentro del CardGroup para mostrar visualmente el progreso de un grupo o proyecto en forma de un círculo SVG. Este círculo se actualiza en función del valor de progreso proporcionado.

**Props:**
```
value (number): El valor del progreso a mostrar como porcentaje (debe estar entre 0 y 100).
size (number, opcional): El tamaño total del SVG, en píxeles. El valor por defecto es 50.
radius (number, opcional): El radio del círculo, en píxeles. El valor por defecto es 10.
```
**Estructura:**

- Un contenedor div que centra el contenido y muestra el valor del progreso en formato de texto.
- Un SVG que contiene dos círculos:
- El primer círculo representa el fondo del progreso.
- El segundo círculo representa el progreso actual, ajustado mediante la propiedad strokeDashoffset.

Ejemplo de uso:

```
<Circleprogress 
    value={75}
    size={100}
    radius={20}
/>
```

Estos dos componentes están diseñados para trabajar en conjunto, donde CardGroup encapsula Circleprogress para proporcionar una representación visual del progreso dentro de una tarjeta de información. Circleprogress es ideal para mostrar visualmente un porcentaje de progreso, mientras que CardGroup ofrece un contexto más amplio al incluir detalles adicionales como el título, la descripción, y el estado del proyecto o grupo.

![image](https://github.com/user-attachments/assets/4b335666-44f7-4e4e-8ff7-fa3cd4e2ee93)
